### PR TITLE
remove unused parameter from approveToken method

### DIFF
--- a/lib/src/fuse_wallet_sdk_base.dart
+++ b/lib/src/fuse_wallet_sdk_base.dart
@@ -455,7 +455,6 @@ class FuseWalletSDK extends EventEmitter {
   Future<DC<Exception, String>> approveToken(
     EthPrivateKey cred,
     String tokenAddress,
-    int tokenDecimals,
     String value, {
     String? spenderContract,
     Map<String, dynamic>? transactionBody,


### PR DESCRIPTION
This PR removes unused parameter `tokenDecimals` from the method `approveToken`.