### PR TITLE
Use built in streams for async operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 # Avoid committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
+
+# IntelliJ
+.idea

--- a/example/explorer.dart
+++ b/example/explorer.dart
@@ -15,10 +15,10 @@ void main() async {
     print("Error occurred in authenticate");
     print(authRes.error);
   } else {
-    final DC<Exception, SmartWallet> walletData = await fuseWalletSDK.fetchWallet();
+    final exceptionOrWallet = await fuseWalletSDK.fetchWallet();
 
     final tokenListData = await fuseWalletSDK.explorerSection.getTokenList(
-      walletData.data!.smartWalletAddress,
+      exceptionOrWallet.data!.smartWalletAddress,
     );
     tokenListData.pick(
       onData: (TokenList tokenList) {
@@ -49,7 +49,7 @@ void main() async {
     final tokenBalanceData =
         await fuseWalletSDK.explorerSection.getTokenBalance(
       Variables.NATIVE_TOKEN_ADDRESS,
-      walletData.data!.smartWalletAddress,
+      exceptionOrWallet.data!.smartWalletAddress,
     );
     tokenBalanceData.pick(
       onData: (BigInt value) {

--- a/example/historical_txs.dart
+++ b/example/historical_txs.dart
@@ -1,6 +1,6 @@
-import 'dart:io';
-
 import 'package:fuse_wallet_sdk/fuse_wallet_sdk.dart';
+
+import 'create_wallet.dart';
 
 void main() async {
   final String privateKey = await Mnemonic.generatePrivateKey();
@@ -15,8 +15,7 @@ void main() async {
     print("Error occurred in authenticate");
     print(authRes.error);
   } else {
-    final DC<Exception, SmartWallet> walletData =
-        await fuseWalletSDK.fetchWallet();
+    final walletData = await fuseWalletSDK.fetchWallet();
 
     walletData.pick(
       onData: (SmartWallet smartWallet) async {
@@ -34,24 +33,7 @@ void main() async {
       onError: (Exception exception) async {
         print('Fetch wallet failed, wallet was not created yet');
         print('creating...');
-        // Create Wallet subscriptions
-        fuseWalletSDK.on('smartWalletCreationStarted', (eventData) {
-          print('smartWalletCreationStarted ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('transactionHash', (eventData) {
-          print('transactionHash ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('smartWalletCreationSucceeded', (eventData) {
-          print('smartWalletCreationSucceeded ${eventData.toString()}');
-          exit(1);
-        });
-        fuseWalletSDK.on('smartWalletCreationFailed', (eventData) {
-          print('smartWalletCreationFailed ${eventData.toString()}');
-          exit(1);
-        });
-
-        // Create Wallet
-        await fuseWalletSDK.createWallet();
+        createWalletAndListenToSmartWalletEventStream(fuseWalletSDK);
       },
     );
   }

--- a/example/stake_token.dart
+++ b/example/stake_token.dart
@@ -1,4 +1,9 @@
+import 'dart:io';
+
 import 'package:fuse_wallet_sdk/fuse_wallet_sdk.dart';
+import 'package:fuse_wallet_sdk/src/models/smart_wallet/smart_wallet_event.dart';
+
+import 'create_wallet.dart';
 
 void main() async {
   final String privateKey = await Mnemonic.generatePrivateKey();
@@ -17,51 +22,54 @@ void main() async {
 
     walletData.pick(
       onData: (SmartWallet smartWallet) async {
-        // Relay subscriptions
-        fuseWalletSDK.on('transactionStarted', (eventData) {
-          print('transactionStarted ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('transactionHash', (eventData) {
-          print('transactionHash ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('transactionSucceeded', (eventData) {
-          print('transactionSucceeded ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('transactionFailed', (eventData) {
-          print('transactionFailed ${eventData.toString()}');
-        });
-
-        final StakeRequestBody stakeRequestBody = StakeRequestBody(
+        final stakeRequestBody = StakeRequestBody(
           accountAddress: smartWallet.smartWalletAddress,
           tokenAmount: 'TOKEN_AMOUNT',
           tokenAddress: "TOKEN_ADDRESS",
         );
-        // Sending a gasless transaction
-        await fuseWalletSDK.stakeToken(
+
+        final exceptionOrStream = await fuseWalletSDK.stakeToken(
           credentials,
           stakeRequestBody,
         );
+
+        if (exceptionOrStream.hasError) {
+          final defaultException =
+              Exception("An error occurred while staking tokens.");
+          final exception = exceptionOrStream.error ?? defaultException;
+          print(exception.toString());
+          exit(1);
+        }
+
+        final smartWalletEventStream = exceptionOrStream.data!;
+        smartWalletEventStream.listen(
+          _onSmartWalletEventStream,
+          onError: (error) {
+            print('Error occurred: ${error.toString()}');
+            exit(1);
+          },
+        );
       },
       onError: (Exception exception) async {
-        print('Fetch wallet failed, wallet was not created yet');
-        print('creating...');
-        // Create Wallet subscriptions
-        fuseWalletSDK.on('smartWalletCreationStarted', (eventData) {
-          print('smartWalletCreationStarted ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('transactionHash', (eventData) {
-          print('transactionHash ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('smartWalletCreationSucceeded', (eventData) {
-          print('smartWalletCreationSucceeded ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('smartWalletCreationFailed', (eventData) {
-          print('smartWalletCreationFailed ${eventData.toString()}');
-        });
-
-        // Create Wallet
-        await fuseWalletSDK.createWallet();
+        createWalletAndListenToSmartWalletEventStream(fuseWalletSDK);
       },
     );
+  }
+}
+
+void _onSmartWalletEventStream(SmartWalletEvent event) {
+  switch (event.name) {
+    case 'transactionStarted':
+      print('transactionStarted ${event.data.toString()}');
+      break;
+    case 'transactionHash':
+      print('transactionHash ${event.data.toString()}');
+      break;
+    case 'transactionSucceeded':
+      print('transactionSucceeded ${event.data.toString()}');
+      break;
+    case 'transactionFailed':
+      print('transactionFailed ${event.data.toString()}');
+      break;
   }
 }

--- a/example/transfer_token.dart
+++ b/example/transfer_token.dart
@@ -67,16 +67,16 @@ void main() async {
 void _onSmartWalletEvent(SmartWalletEvent event) {
   switch (event.name) {
     case 'transactionStarted':
-      print('transactionStarted ${event.toString()}');
+      print('transactionStarted ${event.data.toString()}');
       break;
     case 'transactionHash':
-      print('transactionHash ${event.toString()}');
+      print('transactionHash ${event.data.toString()}');
       break;
     case 'transactionSucceeded':
-      print('transactionSucceeded ${event.toString()}');
+      print('transactionSucceeded ${event.data.toString()}');
       exit(1);
     case 'transactionFailed':
-      print('transactionFailed ${event.toString()}');
+      print('transactionFailed ${event.data.toString()}');
       exit(1);
   }
 }

--- a/example/transfer_token.dart
+++ b/example/transfer_token.dart
@@ -2,6 +2,9 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:fuse_wallet_sdk/fuse_wallet_sdk.dart';
+import 'package:fuse_wallet_sdk/src/models/smart_wallet/smart_wallet_event.dart';
+
+import 'create_wallet.dart';
 
 void main() async {
   final String privateKey = await Mnemonic.generatePrivateKey();
@@ -16,63 +19,64 @@ void main() async {
     print("Error occurred in authenticate");
     print(authRes.error);
   } else {
-    final DC<Exception, SmartWallet> walletData =
-        await fuseWalletSDK.fetchWallet();
+    final exceptionWallet = await fuseWalletSDK.fetchWallet();
 
-    walletData.pick(
+    exceptionWallet.pick(
       onData: (SmartWallet smartWallet) async {
         final String receiverAddress = '0x..';
         final String tokenAddress = Variables.NATIVE_TOKEN_ADDRESS;
         print(
-            'Fund your smart wallet: ${smartWallet.smartWalletAddress} with Fuse to test transfer, and press any key.');
+          'Fund your smart wallet: ${smartWallet.smartWalletAddress} with '
+          'Fuse to test transfer, and press any key.',
+        );
         stdin.readLineSync(encoding: Encoding.getByName('utf-8')!)!;
 
-        // Relay subscriptions
-        fuseWalletSDK.on('transactionStarted', (eventData) {
-          print('transactionStarted ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('transactionHash', (eventData) {
-          print('transactionHash ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('transactionSucceeded', (eventData) async {
-          print('transactionSucceeded ${eventData.toString()}');
-          exit(1);
-        });
-        fuseWalletSDK.on('transactionFailed', (eventData) {
-          print('transactionFailed ${eventData.toString()}');
-          exit(1);
-        });
-
-        // Sending gasless transaction
-        await fuseWalletSDK.transferToken(
+        final exceptionOrStream = await fuseWalletSDK.transferToken(
           credentials,
           tokenAddress,
           receiverAddress,
           '0.0001',
         );
+
+        if (exceptionOrStream.hasError) {
+          final defaultTransferTokenException =
+              Exception("An error occurred while transferring token.");
+          final exception =
+              exceptionOrStream.error ?? defaultTransferTokenException;
+          print(exception.toString());
+          exit(1);
+        }
+
+        final smartWalletEventStream = exceptionOrStream.data!;
+
+        smartWalletEventStream.listen(
+          _onSmartWalletEvent,
+          onError: (error) {
+            print('Error occurred: ${error.toString()}');
+            exit(1);
+          },
+        );
       },
       onError: (Exception exception) async {
-        print('Fetch wallet failed, wallet was not created yet');
-        print('creating...');
-        // Create Wallet subscriptions
-        fuseWalletSDK.on('smartWalletCreationStarted', (eventData) {
-          print('smartWalletCreationStarted ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('transactionHash', (eventData) {
-          print('transactionHash ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('smartWalletCreationSucceeded', (eventData) {
-          print('smartWalletCreationSucceeded ${eventData.toString()}');
-          exit(1);
-        });
-        fuseWalletSDK.on('smartWalletCreationFailed', (eventData) {
-          print('smartWalletCreationFailed ${eventData.toString()}');
-          exit(1);
-        });
-
-        // Create Wallet
-        await fuseWalletSDK.createWallet();
+        createWalletAndListenToSmartWalletEventStream(fuseWalletSDK);
       },
     );
+  }
+}
+
+void _onSmartWalletEvent(SmartWalletEvent event) {
+  switch (event.name) {
+    case 'transactionStarted':
+      print('transactionStarted ${event.toString()}');
+      break;
+    case 'transactionHash':
+      print('transactionHash ${event.toString()}');
+      break;
+    case 'transactionSucceeded':
+      print('transactionSucceeded ${event.toString()}');
+      exit(1);
+    case 'transactionFailed':
+      print('transactionFailed ${event.toString()}');
+      exit(1);
   }
 }

--- a/example/unstake_token.dart
+++ b/example/unstake_token.dart
@@ -1,12 +1,16 @@
 import 'dart:io';
 
 import 'package:fuse_wallet_sdk/fuse_wallet_sdk.dart';
+import 'package:fuse_wallet_sdk/src/models/smart_wallet/smart_wallet_event.dart';
+
+import 'create_wallet.dart';
 
 void main() async {
-  final String privateKey = await Mnemonic.generatePrivateKey();
+  // final String privateKey = await Mnemonic.generatePrivateKey();
+  final privateKey = "2d4c3d2defb3860d21004588c14a153b006b5603f6a5e6f4aed7685deb9c4e29";
   final EthPrivateKey credentials = EthPrivateKey.fromHex(privateKey);
   // Create a project: https://developers.fuse.io
-  final String publicApiKey = '';
+  final String publicApiKey = 'pk_F7gisUhUTV5LyiNcftikb0UL';
   final FuseWalletSDK fuseWalletSDK = FuseWalletSDK(publicApiKey);
   final DC<Exception, String> authRes = await fuseWalletSDK.authenticate(
     credentials,
@@ -19,56 +23,55 @@ void main() async {
 
     walletData.pick(
       onData: (SmartWallet smartWallet) async {
-        // Relay subscriptions
-        fuseWalletSDK.on('transactionStarted', (eventData) {
-          print('transactionStarted ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('transactionHash', (eventData) {
-          print('transactionHash ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('transactionSucceeded', (eventData) {
-          print('transactionSucceeded ${eventData.toString()}');
-          exit(1);
-        });
-        fuseWalletSDK.on('transactionFailed', (eventData) {
-          print('transactionFailed ${eventData.toString()}');
-          exit(1);
-        });
-
-        final UnstakeRequestBody unstakeRequestBody = UnstakeRequestBody(
+        final unstakeRequestBody = UnstakeRequestBody(
           accountAddress: smartWallet.smartWalletAddress,
           tokenAmount: 'TOKEN_AMOUNTS',
           tokenAddress: "0x34Ef2Cc892a88415e9f02b91BfA9c91fC0bE6bD4",
         );
 
-        // Sending a gasless transaction
-        await fuseWalletSDK.unstakeToken(
+        final exceptionOrStream = await fuseWalletSDK.unstakeToken(
           credentials,
           unstakeRequestBody,
         );
+
+        if (exceptionOrStream.hasError) {
+          final defaultException = Exception(
+            "An error occurred while unstaking token.",
+          );
+          final exception = exceptionOrStream.error ?? defaultException;
+          print(exception.toString());
+          exit(1);
+        }
+
+        final smartWalletEventStream = exceptionOrStream.data!;
+        smartWalletEventStream.listen(
+          _onSmartWalletEvent,
+          onError: (error) {
+            print('Error occurred: ${error.toString()}');
+            exit(1);
+          },
+        );
       },
       onError: (Exception exception) async {
-        print('Fetch wallet failed, wallet was not created yet');
-        print('creating...');
-        // Create Wallet subscriptions
-        fuseWalletSDK.on('smartWalletCreationStarted', (eventData) {
-          print('smartWalletCreationStarted ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('transactionHash', (eventData) {
-          print('transactionHash ${eventData.toString()}');
-        });
-        fuseWalletSDK.on('smartWalletCreationSucceeded', (eventData) {
-          print('smartWalletCreationSucceeded ${eventData.toString()}');
-          exit(1);
-        });
-        fuseWalletSDK.on('smartWalletCreationFailed', (eventData) {
-          print('smartWalletCreationFailed ${eventData.toString()}');
-          exit(1);
-        });
-
-        // Create Wallet
-        await fuseWalletSDK.createWallet();
+        createWalletAndListenToSmartWalletEventStream(fuseWalletSDK);
       },
     );
+  }
+}
+
+void _onSmartWalletEvent(SmartWalletEvent event) {
+  switch (event.name) {
+    case 'transactionStarted':
+      print('transactionStarted ${event.data.toString()}');
+      break;
+    case 'transactionHash':
+      print('transactionHash ${event.data.toString()}');
+      break;
+    case 'transactionSucceeded':
+      print('transactionSucceeded ${event.data.toString()}');
+      break;
+    case 'transactionFailed':
+      print('transactionFailed ${event.data.toString()}');
+      break;
   }
 }

--- a/example/unstake_token.dart
+++ b/example/unstake_token.dart
@@ -6,11 +6,10 @@ import 'package:fuse_wallet_sdk/src/models/smart_wallet/smart_wallet_event.dart'
 import 'create_wallet.dart';
 
 void main() async {
-  // final String privateKey = await Mnemonic.generatePrivateKey();
-  final privateKey = "2d4c3d2defb3860d21004588c14a153b006b5603f6a5e6f4aed7685deb9c4e29";
+  final String privateKey = await Mnemonic.generatePrivateKey();
   final EthPrivateKey credentials = EthPrivateKey.fromHex(privateKey);
   // Create a project: https://developers.fuse.io
-  final String publicApiKey = 'pk_F7gisUhUTV5LyiNcftikb0UL';
+  final String publicApiKey = '';
   final FuseWalletSDK fuseWalletSDK = FuseWalletSDK(publicApiKey);
   final DC<Exception, String> authRes = await fuseWalletSDK.authenticate(
     credentials,

--- a/lib/src/models/smart_wallet/smart_wallet_event.dart
+++ b/lib/src/models/smart_wallet/smart_wallet_event.dart
@@ -1,0 +1,6 @@
+class SmartWalletEvent {
+  final String name;
+  final dynamic data;
+
+  const SmartWalletEvent({required this.name, required this.data});
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
   data_channel: ^2.0.0+1
   decimal: ^2.3.2
   dio: ^4.0.6
-  events_emitter: ^0.5.2
   freezed_annotation: ^2.2.0
   gql: ^0.14.0
   graphql: ^5.1.3


### PR DESCRIPTION
This PR is about making use of the built-in [Stream](https://api.dart.dev/stable/2.19.4/dart-async/Stream-class.html) class in methods that work with the WebSocket. Instead of making the `FuseWalletSDK` and `EventEmitter` and emitting events, we can return `Stream`s from methods when necessary. The current way of working with methods that work with the WebSocket is registering callbacks to events like below:

```
 fuseWalletSDK.on('smartWalletCreationStarted', (eventData) {
    print('smartWalletCreationStarted ${eventData.toString()}');
  });

  fuseWalletSDK.on('transactionHash', (eventData) {
    print('transactionHash ${eventData.toString()}');
  });

  fuseWalletSDK.on('smartWalletCreationSucceeded', (eventData) {
    print('smartWalletCreationSucceeded ${eventData.toString()}');
    exit(1);
  });

  fuseWalletSDK.on('smartWalletCreationFailed', (eventData) {
    print('smartWalletCreationFailed ${eventData.toString()}');
    exit(1);
  });
```
and then finally calling the method:
`await fuseWalletSDK.createWallet();`

This works but it is a requirement to register the listeners before calling the method in order to act according to the events. There's a chance that developers may forget to register listeners before calling the method since the method returns `Future<DC<Exception, String>>`. The right side of `DC` is the **transaction ID** which is of type `String`. This does not indicate that one has to make sure to register callbacks in order to act according to the events that will be emitted. To resolve this, we can return `Stream`s instead of the transaction ID and let developers listen to the `Stream` and register callbacks. With this change, it will also be possible to use a [StreamBuilder](https://api.flutter.dev/flutter/widgets/StreamBuilder-class.html) to rebuild the UI whenever an event is emitted.

The example code in example folder have been refactored to use the `Stream` returned from methods.

### Summary
- Return `Stream`s from methods that work with the WebSocket such as `createWallet`.
- Remove the `events_emitter` package.