### PR TITLE
remove the late and final keywords from webSocketConnection

### DIFF
--- a/lib/src/fuse_wallet_sdk_base.dart
+++ b/lib/src/fuse_wallet_sdk_base.dart
@@ -29,7 +29,7 @@ class FuseWalletSDK {
   /// The Web3 client used for sending requests over an HTTP JSON-RPC API endpoint to Ethereum clients.
   final Web3Client web3client;
 
-  late final WebSocketConnection webSocketConnection;
+  WebSocketConnection? webSocketConnection;
 
   /// Constructs a new instance of [FuseWalletSDK].
   ///
@@ -836,7 +836,7 @@ class FuseWalletSDK {
   }
 
   Stream<SmartWalletEvent> _createSubscriptionStream(String transactionId) {
-    return webSocketConnection.client
+    return webSocketConnection!.client
         .newSubscription('transaction:#$transactionId')
         .publication
         .map(_toSmartWalletEventStream);


### PR DESCRIPTION
Client apps may call `authenticate` multiple times. Since `webSocketConnection` was marked as late final, trying to assign a value to it throws an exception.

```
Exception: Error in get wallet info: Exception: LateInitializationError: Field 'webSocketConnection' has already been initialized.
```

To resolve this issue, I've removed the `late` and `final` keywords from webSocketConnection field.